### PR TITLE
avoid warning when path exists

### DIFF
--- a/LCD35-show
+++ b/LCD35-show
@@ -1,5 +1,5 @@
 #!/bin/bash
-sudo mkdir /etc/X11/xorg.conf.d
+sudo mkdir -p /etc/X11/xorg.conf.d
 sudo cp ./usr/tft35a-overlay.dtb /boot/overlays/
 sudo cp ./usr/tft35a-overlay.dtb /boot/overlays/tft35a.dtbo
 sudo cp -rf ./usr/99-calibration.conf-35  /etc/X11/xorg.conf.d/99-calibration.conf


### PR DESCRIPTION
mostly using mkdir -p is the best option to avoid unnecessary warnings and errors when parent paths not exists. I'm not looked into the other scripts, but I guess there is the same situation .. would be nice to fix this