### PR TITLE
Update LCD35-show

### DIFF
--- a/LCD35-show
+++ b/LCD35-show
@@ -4,7 +4,11 @@ sudo cp ./usr/tft35a-overlay.dtb /boot/overlays/
 sudo cp ./usr/tft35a-overlay.dtb /boot/overlays/tft35a.dtbo
 sudo cp -rf ./usr/99-calibration.conf-35  /etc/X11/xorg.conf.d/99-calibration.conf
 sudo cp -rf ./usr/99-fbturbo.conf  /usr/share/X11/xorg.conf.d/
-sudo cp ./usr/cmdline.txt /boot/
+if [ -b /dev/mmcblk0p7 ]; then
+  sudo cp ./usr/cmdline.txt-noobs /boot/cmdline.txt
+else
+  sudo cp ./usr/cmdline.txt /boot/
+fi 
 sudo cp ./usr/inittab /etc/
 sudo cp ./boot/config-35.txt /boot/config.txt
 nodeplatform=`uname -n`


### PR DESCRIPTION
if statement checks if NOOBS OS is present by checking for mmcblk0p7 block. 
Then another cmdline.txt is needed, otherwise system would crash with a kernel panic