### PR TITLE
update for NOOBS users

### DIFF
--- a/LCD7B-show
+++ b/LCD7B-show
@@ -1,5 +1,9 @@
 sudo cp -rf ./boot/config-7B-800x480.txt /boot/config.txt 
-sudo cp ./usr/cmdline.txt /boot/
+if [ -b /dev/mmcblk0p7 ]; then
+  sudo cp ./usr/cmdline.txt-noobs /boot/cmdline.txt
+else
+  sudo cp ./usr/cmdline.txt /boot/
+fi 
 sudo cp ./usr/inittab /etc/
 sudo cp -rf ./usr/99-fbturbo.conf-HDMI /usr/share/X11/xorg.conf.d/99-fbturbo.conf 
 sudo reboot


### PR DESCRIPTION
copied from lavolp3's solution
if statement checks if NOOBS OS is present by checking for mmcblk0p7 block.
Then another cmdline.txt is needed, otherwise system would crash with a kernel panic