### PR TITLE
cmdline filename fix for noobs

### DIFF
--- a/usr/cmdline.txt-noobs
+++ b/usr/cmdline.txt-noobs
@@ -1,0 +1,1 @@
+dwc_otg.lpm_enable=0 console=tty1 console=ttyAMA0,115200 root=/dev/mmcblk0p7 rootfstype=ext4 elevator=deadline rootwait fbcon=map:10 fbcon=font:ProFont6x11 logo.nologo


### PR DESCRIPTION
in executable scripts, filename for cmdline noobs is wrong.
i copied original cmdline.txt_noobs file to cmdline.txt-noobs.
so, /boot/cmdline will be correct by this update and LCD will work.
