### PR TITLE
Backup custom configs in /etc/X11/xorg.conf.d and remove need for dpkg

### DIFF
--- a/system_backup.sh
+++ b/system_backup.sh
@@ -17,6 +17,7 @@ fi
 
 if [ -d /etc/X11/xorg.conf.d ]; then
 sudo mkdir -p ./.system_backup/xorg.conf.d
+sudo cp -r /etc/X11/xorg.conf.d/* ./.system_backup/xorg.conf.d
 sudo rm -rf /etc/X11/xorg.conf.d
 fi
 
@@ -46,12 +47,12 @@ fi
 if [ -f /usr/share/X11/xorg.conf.d/99-fbturbo.conf ]; then
 sudo cp -rf /usr/share/X11/xorg.conf.d/99-fbturbo.conf ./.system_backup/
 fi
-sudo cp -rf ./usr/99-fbturbo.conf-original /usr/share/X11/xorg.conf.d/99-fbturbo.conf
+#sudo cp -rf ./usr/99-fbturbo.conf-original /usr/share/X11/xorg.conf.d/99-fbturbo.conf
 sudo cp -rf /etc/rc.local ./.system_backup/
-sudo cp -rf ./etc/rc.local-original /etc/rc.local
+#sudo cp -rf ./etc/rc.local-original /etc/rc.local
 
 sudo cp -rf /etc/modules ./.system_backup/
-sudo cp -rf ./etc/modules-original /etc/modules
+#sudo cp -rf ./etc/modules-original /etc/modules
 
 if [ -f /etc/modprobe.d/fbtft.conf ]; then
 sudo cp -rf /etc/modprobe.d/fbtft.conf ./.system_backup
@@ -79,7 +80,7 @@ fi
 
 if [ -f /usr/share/X11/xorg.conf.d/10-evdev.conf ]; then
 sudo cp -rf /usr/share/X11/xorg.conf.d/10-evdev.conf ./.system_backup
-sudo dpkg -P xserver-xorg-input-evdev
+#sudo dpkg -P xserver-xorg-input-evdev
 #sudo apt-get purge xserver-xorg-input-evdev -y  2> error_output.txt
 #result=`cat ./error_output.txt`
 #echo -e "\033[31m$result\033[0m"

--- a/system_backup.sh
+++ b/system_backup.sh
@@ -37,13 +37,6 @@ fi
 root_dev=`grep -oPr "root=[^\s]*" /boot/cmdline.txt | awk -F= '{printf $NF}'`
 sudo cp -rf /boot/config.txt ./.system_backup
 sudo cp -rf /boot/cmdline.txt ./.system_backup/
-if test "$root_dev" = "/dev/mmcblk0p7";then
-sudo cp -rf ./boot/config-noobs-nomal.txt /boot/config.txt
-#sudo cp -rf ./usr/cmdline.txt-noobs-original /boot/cmdline.txt
-else
-sudo cp -rf ./boot/config-nomal.txt /boot/config.txt
-#sudo cp -rf ./usr/cmdline.txt-original /boot/cmdline.txt
-fi
 if [ -f /usr/share/X11/xorg.conf.d/99-fbturbo.conf ]; then
 sudo cp -rf /usr/share/X11/xorg.conf.d/99-fbturbo.conf ./.system_backup/
 fi

--- a/system_restore.sh
+++ b/system_restore.sh
@@ -69,18 +69,18 @@ fi
 #echo -e "\033[31m$result\033[0m"
 #fi
 
-if [ -f /usr/share/X11/xorg.conf.d/10-evdev.conf ]; then
-sudo dpkg -P xserver-xorg-input-evdev
-#sudo apt-get purge xserver-xorg-input-evdev -y 2> error_output.txt
-#result=`cat ./error_output.txt`
-#echo -e "\033[31m$result\033[0m"
-fi
-if [ -f ./.system_backup/10-evdev.conf ]; then
-sudo dpkg -i -B ./xserver-xorg-input-evdev_1%3a2.10.6-1+b1_armhf.deb
-#sudo apt-get install xserver-xorg-input-evdev -y 2> error_output.txt
-#result=`cat ./error_output.txt`
-#echo -e "\033[31m$result\033[0m"
-fi
+# if [ -f /usr/share/X11/xorg.conf.d/10-evdev.conf ]; then
+# sudo dpkg -P xserver-xorg-input-evdev
+# #sudo apt-get purge xserver-xorg-input-evdev -y 2> error_output.txt
+# #result=`cat ./error_output.txt`
+# #echo -e "\033[31m$result\033[0m"
+# fi
+# if [ -f ./.system_backup/10-evdev.conf ]; then
+# sudo dpkg -i -B ./xserver-xorg-input-evdev_1%3a2.10.6-1+b1_armhf.deb
+# #sudo apt-get install xserver-xorg-input-evdev -y 2> error_output.txt
+# #result=`cat ./error_output.txt`
+# #echo -e "\033[31m$result\033[0m"
+# fi
 
 if [ -f /usr/share/X11/xorg.conf.d/45-evdev.conf ]; then
 sudo rm -rf /usr/share/X11/xorg.conf.d/45-evdev.conf


### PR DESCRIPTION
Ensure that any custom configurations in `/etc/X11/xorg.conf.d` are backed up alongside configs for this project, and that these custom configs are restored properly as well. Also commented out lines in `system_backup.sh` and `system_restore.sh` that dealt with `dpkg`, since that is distro-specific. This may result in the evdev driver being left on the system, but I don't think that is an issue.