### PR TITLE
Arch compatibility

### DIFF
--- a/Arch-Linux/LCD-hdmi
+++ b/Arch-Linux/LCD-hdmi
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Change directory to get easy access to scripts from the main directory
+
+#dev=`grep -rn "Option" /usr/share/X11/xorg.conf.d/99-fbturbo.conf | grep "fbdev" |awk -F\" '{printf $4}'`
+#if test "$dev" = "/dev/fb0";then
+#echo "The system is already output for HDMI and does not need to be set up any more"
+#exit
+#fi
+sudo ./system_backup.sh
+sudo cp -rf ./boot/config-nomal.txt ./boot/config.txt.bak
+sudo echo "hdmi_force_hotplug=1" >> ./boot/config.txt.bak
+sudo cp -rf ./boot/config.txt.bak /boot/config.txt
+
+sudo sync
+sudo sync
+#sudo cp -rf ./usr/modules-HDMI  /etc/modules
+sudo cp -rf ./Arch-Linux/usr/99-fbdev.conf-HDMI  /usr/share/X11/xorg.conf.d/99-fbdev.conf
+#sudo cp ./boot/config-nomal.txt /boot/config.txt
+#if [ -b /dev/mmcblk0p7 ]; then
+#sudo cp ./usr/cmdline.txt-noobs /boot/cmdline.txt
+#else
+#sudo cp ./usr/cmdline.txt /boot/
+#fi
+#sudo cp ./usr/inittab /etc/
+echo "reboot now"
+sudo reboot

--- a/Arch-Linux/LCD-hdmi
+++ b/Arch-Linux/LCD-hdmi
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Change directory to get easy access to scripts from the main directory
+cd ..
 
 #dev=`grep -rn "Option" /usr/share/X11/xorg.conf.d/99-fbturbo.conf | grep "fbdev" |awk -F\" '{printf $4}'`
 #if test "$dev" = "/dev/fb0";then

--- a/Arch-Linux/LCD35-show
+++ b/Arch-Linux/LCD35-show
@@ -97,7 +97,7 @@ else
     echo "need to update touch configuration"
     wget --spider -q -o /dev/null --tries=1 -T 10 http://mirrors.zju.edu.cn/raspbian/raspbian
     if [ $? -eq 0 ]; then
-        sudo pacman -S xf86-input-evdev
+        sudo pacman -S --noconfirm --needed xf86-input-evdev
     else
         echo "Evdev input driver could not be installed. Terminating and restoring."
         ./system_restore.sh

--- a/Arch-Linux/LCD35-show
+++ b/Arch-Linux/LCD35-show
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+sudo ./system_backup.sh
+
+# Change working directory up to the main directory to allow easier access to the boot, etc, and usr directories.
+cd ..
+
+if [ -f /etc/X11/xorg.conf.d/40-libinput.conf ]; then
+    sudo rm -rf /etc/X11/xorg.conf.d/40-libinput.conf
+fi
+if [ ! -d /etc/X11/xorg.conf.d ]; then
+    sudo mkdir -p /etc/X11/xorg.conf.d
+fi
+sudo cp ./usr/tft35a-overlay.dtb /boot/overlays/
+sudo cp ./usr/tft35a-overlay.dtb /boot/overlays/tft35a.dtbo
+root_dev=`grep -oPr "root=[^\s]*" /boot/cmdline.txt | awk -F= '{printf $NF}'`
+if test "$root_dev" = "/dev/mmcblk0p7";then
+    sudo cp -rf ./boot/config-noobs-nomal.txt ./boot/config.txt.bak
+else
+    sudo cp -rf ./boot/config-nomal.txt ./boot/config.txt.bak
+    sudo echo "hdmi_force_hotplug=1" >> ./boot/config.txt.bak
+fi
+sudo echo "dtparam=i2c_arm=on" >> ./boot/config.txt.bak
+sudo echo "dtparam=spi=on" >> ./boot/config.txt.bak
+sudo echo "enable_uart=1" >> ./boot/config.txt.bak
+sudo echo "dtoverlay=tft35a:rotate=90" >> ./boot/config.txt.bak
+sudo echo "hdmi_group=2" >> ./boot/config.txt.bak
+sudo echo "hdmi_mode=1" >> ./boot/config.txt.bak
+sudo echo "hdmi_mode=87" >> ./boot/config.txt.bak
+sudo echo "hdmi_cvt 480 320 60 6 0 0 0" >> ./boot/config.txt.bak
+sudo echo "hdmi_drive=2" >> ./boot/config.txt.bak
+sudo cp -rf ./boot/config.txt.bak /boot/config.txt
+
+sudo cp -rf ./usr/99-calibration.conf-35-90  /etc/X11/xorg.conf.d/99-calibration.conf
+sudo cp -rf ./Arch-Linux/usr/99-fbdev.conf  /usr/share/X11/xorg.conf.d/99-fbdev.conf
+#if test "$root_dev" = "/dev/mmcblk0p7";then
+#sudo cp ./usr/cmdline.txt-noobs /boot/cmdline.txt
+#else
+#sudo cp ./usr/cmdline.txt /boot/
+#fi
+sudo cp ./usr/inittab /etc/
+#sudo cp ./boot/config-35.txt /boot/config.txt
+sudo touch ./.have_installed
+echo "gpio:resistance:35:90:480:320" > ./.have_installed
+
+#FBCP install
+wget --spider -q -o /dev/null --tries=1 -T 10 https://cmake.org/
+if [ $? -eq 0 ]; then
+    sudo pacman -Sy --needed --noconfirm cmake 2> error_output.txt
+    result=`cat ./error_output.txt`
+    echo -e "\033[31m$result\033[0m"
+    grep -q "^E:" ./error_output.txt
+    type cmake > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        sudo rm -rf rpi-fbcp
+        wget --spider -q -o /dev/null --tries=1 -T 10 https://github.com
+        if [ $? -eq 0 ]; then
+            sudo git clone https://github.com/tasanakorn/rpi-fbcp
+            if [ $? -ne 0 ]; then
+                echo "download fbcp failed, copy native fbcp!!!"
+                sudo cp -r ./usr/rpi-fbcp .
+            fi
+        else
+            echo "bad network, copy native fbcp!!!"
+            sudo cp -r ./usr/rpi-fbcp .
+        fi
+        sudo mkdir ./rpi-fbcp/build
+        cd ./rpi-fbcp/build/
+        sudo cmake ..
+        sudo make
+        sudo install fbcp /usr/local/bin/fbcp
+        cd - > /dev/null
+        type fbcp > /dev/null 2>&1
+        if [ $? -eq 0 ]; then
+            sudo cp -rf ./Arch-Linux/usr/99-fbturbo-fbcp.conf  /usr/share/X11/xorg.conf.d/99-fbturbo.conf
+            sudo cp -rf ./etc/rc.local /etc/rc.local
+        fi
+    else
+        echo "install cmake error!!!!"
+    fi
+else
+    echo "bad network, can't install cmake!!!"
+fi
+
+#evdev install
+#nodeplatform=`uname -n`
+#kernel=`uname -r`
+version=`uname -v`
+#if test "$nodeplatform" = "raspberrypi";then
+#echo "this is raspberrypi kernel"
+version=${version##* }
+#version=${version#*#}
+echo $version
+if test $version -lt 2017;then
+    echo "reboot"
+else
+    echo "need to update touch configuration"
+    wget --spider -q -o /dev/null --tries=1 -T 10 http://mirrors.zju.edu.cn/raspbian/raspbian
+    if [ $? -eq 0 ]; then
+        sudo pacman -S xf86-input-evdev
+    else
+        echo "Evdev input driver could not be installed. Terminating and restoring."
+        ./system_restore.sh
+    fi
+    result=`cat ./error_output.txt`
+    echo -e "\033[31m$result\033[0m"
+    grep -q "error:" ./error_output.txt && exit
+    sudo cp -rf /usr/share/X11/xorg.conf.d/10-evdev.conf /usr/share/X11/xorg.conf.d/45-evdev.conf
+    #echo "reboot"
+fi
+#else
+#echo "this is not raspberrypi kernel, no need to update touch configure, reboot"
+#fi
+
+sudo sync
+sudo sync
+sleep 1
+if [ $# -eq 1 ]; then
+sudo ./rotate.sh $1
+elif [ $# -gt 1 ]; then
+echo "Too many parameters"
+fi
+
+echo "reboot now"
+sudo reboot

--- a/Arch-Linux/LCD35-show
+++ b/Arch-Linux/LCD35-show
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-sudo ./system_backup.sh
-
 # Change working directory up to the main directory to allow easier access to the boot, etc, and usr directories.
 cd ..
+
+sudo ./system_backup.sh
 
 if [ -f /etc/X11/xorg.conf.d/40-libinput.conf ]; then
     sudo rm -rf /etc/X11/xorg.conf.d/40-libinput.conf
@@ -72,7 +72,7 @@ if [ $? -eq 0 ]; then
         cd - > /dev/null
         type fbcp > /dev/null 2>&1
         if [ $? -eq 0 ]; then
-            sudo cp -rf ./Arch-Linux/usr/99-fbturbo-fbcp.conf  /usr/share/X11/xorg.conf.d/99-fbturbo.conf
+            sudo cp -rf ./Arch-Linux/usr/99-fbdev-fbcp.conf  /usr/share/X11/xorg.conf.d/99-fbdev.conf
             sudo cp -rf ./etc/rc.local /etc/rc.local
         fi
     else

--- a/Arch-Linux/rotate.sh
+++ b/Arch-Linux/rotate.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+cur_dir=`pwd`
+if [ ! -f $cur_dir/.have_installed ]; then
+echo "Please install the LCD driver first"
+echo "Usage: sudo ./xxx-show. xxx: MHS35,LCD35,MPI3508 etc."
+exit
+fi
+
+print_info()
+{
+echo "Usage:sudo ./rotate.sh [0] [90] [180] [270] [360] [450]"
+echo "0-Screen rotation 0 degrees"
+echo "90-Screen rotation 90 degrees"
+echo "180-Screen rotation 180 degrees"
+echo "270-Screen rotation 270 degrees"
+echo "360-Screen flip horizontal(Valid only for HDMI screens)"
+echo "450-Screen flip vertical(Valid only for HDMI screens)"
+}
+
+if [ $# -eq 0 ]; then
+echo "Please input parameter:0,90,180,270,360,450"
+print_info
+exit
+elif [ $# -eq 1 ]; then
+if [ ! -n "$(echo $1| sed -n "/^[0-9]\+$/p")" ]; then
+echo "Invalid parameter"
+print_info
+exit
+else
+if [ $1 -ne 0 ] && [ $1 -ne 90 ] && [ $1 -ne 180 ] && [ $1 -ne 270 ] && [ $1 -ne 360 ] && [ $1 -ne 450 ]; then
+echo "Invalid parameter"
+print_info
+exit
+fi
+fi
+else
+echo "Too many parameters, only one parameter allowed"
+exit
+fi
+
+#get screen parameter
+tmp=`cat $cur_dir/.have_installed`
+output_type=`cat $cur_dir/.have_installed | awk -F ':' '{printf $1}'`
+touch_type=`cat $cur_dir/.have_installed | awk -F ':' '{printf $2}'`
+device_id=`cat $cur_dir/.have_installed | awk -F ':' '{printf $3}'`
+default_value=`cat $cur_dir/.have_installed | awk -F ':' '{printf $4}'`
+width=`cat $cur_dir/.have_installed | awk -F ':' '{printf $5}'`
+height=`cat $cur_dir/.have_installed | awk -F ':' '{printf $6}'`
+
+if [ $output_type = "hdmi" ]; then
+result=`grep -rn "^display_rotate=" /boot/config.txt | tail -n 1`
+line=`echo -n $result | awk -F: '{printf $1}'`
+str=`echo -n $result | awk -F: '{printf $NF}'`
+old_rotate_value=`echo -n $result | awk -F= '{printf $NF}'`
+if [ $old_rotate_value = "0x10000" ]; then
+old_rotate_value=4
+elif  [ $old_rotate_value = "0x20000" ]; then
+old_rotate_value=5
+fi
+if [ $1 -eq 0 ] || [ $1 -eq 90 ] || [ $1 -eq 180 ] || [ $1 -eq 270 ]; then
+new_rotate_value=$[(($default_value+$1)%360)/90]
+else
+new_rotate_value=$[$1/90]
+fi
+elif [ $output_type = "gpio" ]; then
+result=`grep -rn "^dtoverlay=" /boot/config.txt | grep ":rotate=" | tail -n 1`
+line=`echo -n $result | awk -F: '{printf $1}'`
+str=`echo -n $result | awk -F: '{printf $NF}'`
+old_rotate_value=`echo -n $result | awk -F= '{printf $NF}'`
+if [ $1 -eq 0 ] || [ $1 -eq 90 ] || [ $1 -eq 180 ] || [ $1 -eq 270 ]; then
+new_rotate_value=$[($default_value+$1)%360]
+else
+echo "Invalid parameter: only for HDMI screens"
+exit
+fi
+else
+echo "Invalid output type"
+exit
+fi
+
+if [ $old_rotate_value -eq $new_rotate_value ]; then
+if [ $output_type = "hdmi" ]; then
+if [ $1 -eq 0 ] || [ $1 -eq 90 ] || [ $1 -eq 180 ] || [ $1 -eq 270 ]; then
+old_rotate_value=$[($old_rotate_value*90+360-$default_value)%360]
+else
+old_rotate_value=$[$old_rotate_value*90]
+fi
+elif [ $output_type = "gpio" ]; then
+old_rotate_value=$[($old_rotate_value+360-$default_value)%360]
+fi
+echo "Current rotate value is $old_rotate_value"
+exit
+fi
+
+#setting LCD rotate
+if [ $output_type = "hdmi" ]; then
+if [ $new_rotate_value -eq 4 ]; then
+sudo sed -i -e ''"$line"'s/'"$str"'/display_rotate=0x10000/' /boot/config.txt
+elif  [ $new_rotate_value -eq 5 ]; then
+sudo sed -i -e ''"$line"'s/'"$str"'/display_rotate=0x20000/' /boot/config.txt
+else
+sudo sed -i -e ''"$line"'s/'"$str"'/display_rotate='"$new_rotate_value"'/' /boot/config.txt
+fi
+new_rotate_value=$[$new_rotate_value*90]
+elif [ $output_type = "gpio" ]; then
+sudo sed -i -e ''"$line"'s/'"$str"'/rotate='"$new_rotate_value"'/' /boot/config.txt
+resultr=`grep -rn "^hdmi_cvt" /boot/config.txt | tail -n 1 | awk -F' ' '{print $1,$2,$3}'`
+if [ -n "$resultr" ]; then
+liner=`echo -n $resultr | awk -F: '{printf $1}'`
+strr=`echo -n $resultr | awk -F: '{printf $2}'`
+if [ $new_rotate_value -eq $default_value ] || [ $new_rotate_value -eq $[($default_value+180+360)%360] ]; then
+sudo sed -i -e ''"$liner"'s/'"$strr"'/hdmi_cvt '"$width"' '"$height"'/' /boot/config.txt
+elif [ $new_rotate_value -eq $[($default_value-90+360)%360] ] || [ $new_rotate_value -eq $[($default_value+90+360)%360] ]; then
+sudo sed -i -e ''"$liner"'s/'"$strr"'/hdmi_cvt '"$height"' '"$width"'/' /boot/config.txt
+fi
+fi
+fi
+
+#setting touch screen rotate
+if [ $touch_type = "resistance" ]; then 
+if [ $new_rotate_value -eq 0 ]; then
+sudo cp $cur_dir/usr/99-calibration.conf-$device_id-0 /etc/X11/xorg.conf.d/99-calibration.conf
+echo "LCD rotate value is set to $1"
+elif [ $new_rotate_value -eq 90 ]; then
+sudo cp $cur_dir/usr/99-calibration.conf-$device_id-90 /etc/X11/xorg.conf.d/99-calibration.conf
+echo "LCD rotate value is set to $1"
+elif [ $new_rotate_value -eq 180 ]; then
+sudo cp $cur_dir/usr/99-calibration.conf-$device_id-180 /etc/X11/xorg.conf.d/99-calibration.conf
+echo "LCD rotate value is set to $1"
+elif [ $new_rotate_value -eq 270 ]; then
+sudo cp $cur_dir/usr/99-calibration.conf-$device_id-270 /etc/X11/xorg.conf.d/99-calibration.conf
+echo "LCD rotate value is set to $1"
+elif [ $new_rotate_value -eq 360 ]; then
+sudo cp $cur_dir/usr/99-calibration.conf-$device_id-FLIP-H /etc/X11/xorg.conf.d/99-calibration.conf
+echo "LCD rotate value is set to flip horizontally"
+elif [ $new_rotate_value -eq 450 ]; then
+sudo cp $cur_dir/usr/99-calibration.conf-$device_id-FLIP-V /etc/X11/xorg.conf.d/99-calibration.conf
+echo "LCD rotate value is set to flip vertically"
+fi
+elif [ $touch_type = "capacity" ]; then
+if [ $new_rotate_value -eq 0 ]; then
+sudo cp $cur_dir/usr/40-libinput.conf-0 /etc/X11/xorg.conf.d/40-libinput.conf
+echo "LCD rotate value is set to $1"
+elif [ $new_rotate_value -eq 90 ]; then
+sudo cp $cur_dir/usr/40-libinput.conf-90 /etc/X11/xorg.conf.d/40-libinput.conf
+echo "LCD rotate value is set to $1"
+elif [ $new_rotate_value -eq 180 ]; then
+sudo cp $cur_dir/usr/40-libinput.conf-180 /etc/X11/xorg.conf.d/40-libinput.conf
+echo "LCD rotate value is set to $1"
+elif [ $new_rotate_value -eq 270 ]; then
+sudo cp $cur_dir/usr/40-libinput.conf-270 /etc/X11/xorg.conf.d/40-libinput.conf
+echo "LCD rotate value is set to $1"
+elif [ $new_rotate_value -eq 360 ]; then
+sudo cp $cur_dir/usr/40-libinput.conf-FLIP-H /etc/X11/xorg.conf.d/40-libinput.conf
+echo "LCD rotate value is set to flip horizontally"
+elif [ $new_rotate_value -eq 450 ]; then
+sudo cp $cur_dir/usr/40-libinput.conf-FLIP-V /etc/X11/xorg.conf.d/40-libinput.conf
+echo "LCD rotate value is set to flip vertically"
+fi
+else
+echo "Invalid touch type"
+exit
+fi
+
+sudo sync
+sudo sync
+
+echo "reboot now"
+sleep 1
+sudo reboot
+

--- a/Arch-Linux/usr/99-fbdev-fbcp.conf
+++ b/Arch-Linux/usr/99-fbdev-fbcp.conf
@@ -1,0 +1,16 @@
+# This is a minimal sample config file, which can be copied to
+# /etc/X11/xorg.conf in order to make the Xorg server pick up
+# and load xf86-video-fbdev driver installed in the system.
+#
+# When troubleshooting, check /var/log/Xorg.0.log for the debugging
+# output and error messages.
+# Run "man fbdev" to get additional information about the extra
+# configuration options for tuning the driver.
+
+Section "Device"
+        Identifier      "Allwinner A10/A13/A20 FBDEV"
+        Driver          "fbdev"
+        Option          "fbdev" "/dev/fb0"
+
+        Option          "SwapbuffersWait" "true"
+EndSection

--- a/Arch-Linux/usr/99-fbdev-fbcp.conf
+++ b/Arch-Linux/usr/99-fbdev-fbcp.conf
@@ -10,7 +10,7 @@
 Section "Device"
         Identifier      "Allwinner A10/A13/A20 FBDEV"
         Driver          "fbdev"
-        Option          "fbdev" "/dev/fb0"
+        Option          "fbdev" "/dev/fb1"
 
         Option          "SwapbuffersWait" "true"
 EndSection

--- a/Arch-Linux/usr/99-fbdev.conf
+++ b/Arch-Linux/usr/99-fbdev.conf
@@ -1,0 +1,16 @@
+# This is a minimal sample config file, which can be copied to
+# /etc/X11/xorg.conf in order to make the Xorg server pick up
+# and load xf86-video-fbdev driver installed in the system.
+#
+# When troubleshooting, check /var/log/Xorg.0.log for the debugging
+# output and error messages.
+# Run "man fbturbo" to get additional information about the extra
+# configuration options for tuning the driver.
+
+Section "Device"
+        Identifier      "Allwinner A10/A13/A20 FBDEV"
+        Driver          "fbdev"
+        Option          "fbdev" "/dev/fb1"
+
+        Option          "SwapbuffersWait" "true"
+EndSection

--- a/Arch-Linux/usr/99-fbdev.conf-HDMI
+++ b/Arch-Linux/usr/99-fbdev.conf-HDMI
@@ -4,13 +4,13 @@
 #
 # When troubleshooting, check /var/log/Xorg.0.log for the debugging
 # output and error messages.
-# Run "man fbdev" to get additional information about the extra
+# Run "man fbturbo" to get additional information about the extra
 # configuration options for tuning the driver.
 
 Section "Device"
         Identifier      "Allwinner A10/A13/A20 FBDEV"
         Driver          "fbdev"
-        Option          "fbdev" "/dev/fb1"
+        Option          "fbdev" "/dev/fb0"
 
         Option          "SwapbuffersWait" "true"
 EndSection

--- a/system_backup.sh
+++ b/system_backup.sh
@@ -17,6 +17,7 @@ fi
 
 if [ -d /etc/X11/xorg.conf.d ]; then
 sudo mkdir -p ./.system_backup/xorg.conf.d
+sudo cp -r /etc/X11/xorg.conf.d/* ./.system_backup/xorg.conf.d
 sudo rm -rf /etc/X11/xorg.conf.d
 fi
 
@@ -46,12 +47,12 @@ fi
 if [ -f /usr/share/X11/xorg.conf.d/99-fbturbo.conf ]; then
 sudo cp -rf /usr/share/X11/xorg.conf.d/99-fbturbo.conf ./.system_backup/
 fi
-sudo cp -rf ./usr/99-fbturbo.conf-original /usr/share/X11/xorg.conf.d/99-fbturbo.conf
+#sudo cp -rf ./usr/99-fbturbo.conf-original /usr/share/X11/xorg.conf.d/99-fbturbo.conf
 sudo cp -rf /etc/rc.local ./.system_backup/
-sudo cp -rf ./etc/rc.local-original /etc/rc.local
+#sudo cp -rf ./etc/rc.local-original /etc/rc.local
 
 sudo cp -rf /etc/modules ./.system_backup/
-sudo cp -rf ./etc/modules-original /etc/modules
+#sudo cp -rf ./etc/modules-original /etc/modules
 
 if [ -f /etc/modprobe.d/fbtft.conf ]; then
 sudo cp -rf /etc/modprobe.d/fbtft.conf ./.system_backup
@@ -79,7 +80,7 @@ fi
 
 if [ -f /usr/share/X11/xorg.conf.d/10-evdev.conf ]; then
 sudo cp -rf /usr/share/X11/xorg.conf.d/10-evdev.conf ./.system_backup
-sudo dpkg -P xserver-xorg-input-evdev
+#sudo dpkg -P xserver-xorg-input-evdev
 #sudo apt-get purge xserver-xorg-input-evdev -y  2> error_output.txt
 #result=`cat ./error_output.txt`
 #echo -e "\033[31m$result\033[0m"

--- a/system_backup.sh
+++ b/system_backup.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
 if [ ! -d "./.system_backup" ]; then
 sudo mkdir ./.system_backup
+else
+    echo "It looks like a backup of your previous configuration already exists. Would you like to delete that backup and create a new one of the current configuration? [Y]es or [N]o."
+    read override_choice
+    if [ "${override_choice^^}" = "N" ]; then
+        echo "Not overwriting existing backup and cancelling backup process!"
+        exit
+    else
+        echo "Overwriting existing backup to create a new one now."
+    fi
 fi
 
 sudo rm -rf ./.system_backup/*

--- a/system_restore.sh
+++ b/system_restore.sh
@@ -27,6 +27,13 @@ fi
 ls -al ./.system_backup/*.dtb > /dev/null 2>&1 && sudo cp -rf ./.system_backup/*.dtb  /boot/overlays/
 ls -al ./.system_backup/*.dtbo > /dev/null 2>&1 && sudo cp -rf ./.system_backup/*.dtbo  /boot/overlays/
 
+if [ -f /usr/share/X11/xorg.conf.d/99-fbdev.conf ]; then
+    sudo rm -rf /usr/share/X11/xorg.conf.d/99-fbdev.conf
+fi
+if [ -f /usr/share/X11/xorg.conf.d/99-fbturbo.conf ]; then
+    sudo rm -rf /usr/share/X11/xorg.conf.d/99-fbturbo.conf
+fi
+
 if [ -f ./.system_backup/99-fbturbo.conf ];then
 sudo cp -rf ./.system_backup/99-fbturbo.conf /usr/share/X11/xorg.conf.d
 fi

--- a/system_restore.sh
+++ b/system_restore.sh
@@ -69,18 +69,18 @@ fi
 #echo -e "\033[31m$result\033[0m"
 #fi
 
-if [ -f /usr/share/X11/xorg.conf.d/10-evdev.conf ]; then
-sudo dpkg -P xserver-xorg-input-evdev
-#sudo apt-get purge xserver-xorg-input-evdev -y 2> error_output.txt
-#result=`cat ./error_output.txt`
-#echo -e "\033[31m$result\033[0m"
-fi
-if [ -f ./.system_backup/10-evdev.conf ]; then
-sudo dpkg -i -B ./xserver-xorg-input-evdev_1%3a2.10.6-1+b1_armhf.deb
-#sudo apt-get install xserver-xorg-input-evdev -y 2> error_output.txt
-#result=`cat ./error_output.txt`
-#echo -e "\033[31m$result\033[0m"
-fi
+# if [ -f /usr/share/X11/xorg.conf.d/10-evdev.conf ]; then
+# sudo dpkg -P xserver-xorg-input-evdev
+# #sudo apt-get purge xserver-xorg-input-evdev -y 2> error_output.txt
+# #result=`cat ./error_output.txt`
+# #echo -e "\033[31m$result\033[0m"
+# fi
+# if [ -f ./.system_backup/10-evdev.conf ]; then
+# sudo dpkg -i -B ./xserver-xorg-input-evdev_1%3a2.10.6-1+b1_armhf.deb
+# #sudo apt-get install xserver-xorg-input-evdev -y 2> error_output.txt
+# #result=`cat ./error_output.txt`
+# #echo -e "\033[31m$result\033[0m"
+# fi
 
 if [ -f /usr/share/X11/xorg.conf.d/45-evdev.conf ]; then
 sudo rm -rf /usr/share/X11/xorg.conf.d/45-evdev.conf


### PR DESCRIPTION
Updated the LCD35-show script to work on Arch Linux ARM. Also tweaked the backup and restore scripts so that backups don't break an existing configuration and a user is able to restore any custom configuration files in `/etc/X11/xorg.conf.d`. Also removed use of dpkg in system_backup, as that is distro-specific.