### PR TITLE
Update MHS40-show

### DIFF
--- a/MHS40-show
+++ b/MHS40-show
@@ -133,5 +133,8 @@ elif [ $# -gt 1 ]; then
 echo "Too many parameters"
 fi
 
+echo "Removing 99-fturbo"
+sudo mv /usr/share/X11/xorg.conf.d/99-fbturbo.conf ~
+
 echo "reboot now"
 sudo reboot


### PR DESCRIPTION
Moving the 99-fturbo.conf from /usr/share/X11/xorg.conf.d/99-fbturbo.conf to the users home directory solves the issue where X refuses to start due to missing module